### PR TITLE
Use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` as default value in Queue Mode and use `false` for proper CI providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5930,6 +5930,30 @@
         "node": "*"
       }
     },
+    "node_modules/eslint-plugin-jest": {
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
+      "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
@@ -15411,6 +15435,7 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-prettier": "^4.0.0",
         "gulp": "^4.0.2",
         "gulp-typescript": "^5.0.1",
@@ -20228,6 +20253,7 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-prettier": "^4.0.0",
         "gulp": "^4.0.2",
         "gulp-typescript": "^5.0.1",
@@ -24949,6 +24975,15 @@
             "brace-expansion": "^1.1.7"
           }
         }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
+      "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^5.10.0"
       }
     },
     "eslint-plugin-prettier": {

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "prettier"],
+  "plugins": ["@typescript-eslint", "prettier", "jest"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
@@ -9,6 +9,9 @@
     "airbnb-base",
     "prettier"
   ],
+  "env": {
+    "jest/globals": true
+  },
   "rules": {
     "prettier/prettier": "error",
     "no-unused-vars": "warn",

--- a/packages/core/__tests__/ci-env.config.spec.ts
+++ b/packages/core/__tests__/ci-env.config.spec.ts
@@ -1,0 +1,57 @@
+import {
+  AppVeyor,
+  Buildkite,
+  CIProviderBase,
+  CircleCI,
+  CirrusCI,
+  CodefreshCI,
+  Codeship,
+  GithubActions,
+  GitlabCI,
+  HerokuCI,
+  SemaphoreCI,
+  SemaphoreCI2,
+  TravisCI,
+  UnsupportedCI,
+} from '../src/ci-providers';
+import { CIEnvConfig } from '../src/config/ci-env.config';
+
+describe('KnapsackProEnvConfig', () => {
+  // Since we use CircleCI for testing, we prevent it from interfering with the tests.
+  delete process.env.CIRCLECI;
+  const ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ENV };
+  });
+
+  describe('.detectCi', () => {
+    const TESTS: [string, object, typeof CIProviderBase][] = [
+      ['AppVeyor', { APPVEYOR: 'whatever' }, AppVeyor],
+      ['Buildkite', { BUILDKITE: 'whatever' }, Buildkite],
+      ['CircleCI', { CIRCLECI: 'whatever' }, CircleCI],
+      ['Cirrus CI', { CIRRUS_CI: 'whatever' }, CirrusCI],
+      ['Codefresh', { CF_BUILD_ID: 'whatever' }, CodefreshCI],
+      ['Codeship', { CI_NAME: 'codeship' }, Codeship],
+      ['GitHub Actions', { GITHUB_ACTIONS: 'whatever' }, GithubActions],
+      ['GitLab CI', { GITLAB_CI: 'whatever' }, GitlabCI],
+      ['Heroku CI', { HEROKU_TEST_RUN_ID: 'whatever' }, HerokuCI],
+      ['Semaphore CI 1.0', { SEMAPHORE_BUILD_NUMBER: 'whatever' }, SemaphoreCI],
+      [
+        'Semaphore CI 2.0',
+        { SEMAPHORE: 'whatever', SEMAPHORE_WORKFLOW_ID: 'whatever' },
+        SemaphoreCI2,
+      ],
+      ['Travis CI', { TRAVIS: 'whatever' }, TravisCI],
+      ['Unsupported CI', {}, UnsupportedCI],
+    ];
+
+    TESTS.forEach(([ci, env, expected]) => {
+      it(`detects ${ci}`, () => {
+        process.env = { ...process.env, ...env };
+
+        expect(CIEnvConfig.detectCi()).toEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/core/__tests__/fallback-test-distributor.spec.ts
+++ b/packages/core/__tests__/fallback-test-distributor.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import { FallbackTestDistributor } from '../src/fallback-test-distributor';
 import { TestFile } from '../src/models';
 

--- a/packages/core/__tests__/knapsack-pro-env.config.spec.ts
+++ b/packages/core/__tests__/knapsack-pro-env.config.spec.ts
@@ -1,18 +1,18 @@
-/* eslint-disable no-undef */
 import { KnapsackProEnvConfig } from '../src/config/knapsack-pro-env.config';
+import { KnapsackProLogger } from '../src/knapsack-pro-logger';
+import * as Urls from '../src/urls';
 
 describe('KnapsackProEnvConfig', () => {
   // Since we use CircleCI for testing, we prevent it from interfering with the tests.
-  delete process.env.CIRCLE_BUILD_NUM;
-
+  delete process.env.CIRCLECI;
   const ENV = { ...process.env };
 
   afterEach(() => {
-    process.env = ENV;
+    process.env = { ...ENV };
   });
 
   describe('.ciNodeBuildId', () => {
-    describe('when KNAPSACK_PRO_CI_NODE_BUILD_ID is not defined on the environment', () => {
+    describe('when KNAPSACK_PRO_CI_NODE_BUILD_ID is not defined on the environment and the CI is not supported', () => {
       it('throws', () => {
         expect(() => KnapsackProEnvConfig.ciNodeBuildId).toThrow(
           /Missing environment variable KNAPSACK_PRO_CI_NODE_BUILD_ID/,
@@ -23,17 +23,19 @@ describe('KnapsackProEnvConfig', () => {
     describe('when the build id is defined on a supported CI environment', () => {
       it('returns the CI build ID for the supported CI provider', () => {
         const ciBuildId = 'some-build-id';
-        process.env.GITHUB_RUN_ID = ciBuildId;
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_BUILD_NUMBER = ciBuildId;
 
         expect(KnapsackProEnvConfig.ciNodeBuildId).toEqual(ciBuildId);
       });
     });
 
     describe('when KNAPSACK_PRO_CI_NODE_BUILD_ID is defined on the environment AND the build id is defined on a supported CI environment', () => {
-      it('returns the CI build ID defined on the environment', () => {
+      it('returns KNAPSACK_PRO_CI_NODE_BUILD_ID', () => {
         const ciBuildId = 'some-build-id';
         process.env.KNAPSACK_PRO_CI_NODE_BUILD_ID = ciBuildId;
-        process.env.GITHUB_RUN_ID = 'some-other-build-id';
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_BUILD_NUMBER = 'some-other-build-id';
 
         expect(KnapsackProEnvConfig.ciNodeBuildId).toEqual(ciBuildId);
       });
@@ -48,6 +50,7 @@ describe('KnapsackProEnvConfig', () => {
     describe('when the CI provider is Buildkite', () => {
       describe('when BUILDKITE_RETRY_COUNT is set', () => {
         it('returns the retry count', () => {
+          process.env.BUILDKITE = 'true';
           process.env.BUILDKITE_RETRY_COUNT = '1';
 
           expect(KnapsackProEnvConfig.ciNodeRetryCount).toEqual(1);
@@ -58,9 +61,237 @@ describe('KnapsackProEnvConfig', () => {
     describe('when the CI provider is GitHub Actions', () => {
       describe('when GITHUB_RUN_ATTEMPT is set', () => {
         it('returns the retry count', () => {
+          process.env.GITHUB_ACTIONS = 'true';
           process.env.GITHUB_RUN_ATTEMPT = '2';
 
           expect(KnapsackProEnvConfig.ciNodeRetryCount).toEqual(1);
+        });
+      });
+    });
+  });
+
+  describe('.ciNodeTotal', () => {
+    describe('when KNAPSACK_PRO_CI_NODE_TOTAL is not defined on the environment and the CI is not supported', () => {
+      it('throws', () => {
+        expect(() => KnapsackProEnvConfig.ciNodeTotal).toThrow(
+          /Undefined number of total CI nodes/,
+        );
+      });
+    });
+
+    describe('when the ciNodeTotal is defined on a supported CI environment', () => {
+      it('returns the ciNodeTotal for the supported CI provider', () => {
+        const ciNodeTotal = '2';
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_PARALLEL_JOB_COUNT = ciNodeTotal;
+
+        const expected = parseInt(ciNodeTotal, 10);
+        expect(KnapsackProEnvConfig.ciNodeTotal).toEqual(expected);
+      });
+    });
+
+    describe('when KNAPSACK_PRO_CI_NODE_TOTAL is defined on the environment AND the ciNodeTotal is defined on a supported CI environment', () => {
+      it('returns KNAPSACK_PRO_CI_NODE_TOTAL', () => {
+        const ciNodeTotal = '2';
+        process.env.KNAPSACK_PRO_CI_NODE_TOTAL = ciNodeTotal;
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_PARALLEL_JOB_COUNT = '3';
+
+        const expected = parseInt(ciNodeTotal, 10);
+        expect(KnapsackProEnvConfig.ciNodeTotal).toEqual(expected);
+      });
+    });
+  });
+
+  describe('.ciNodeIndex', () => {
+    describe('when KNAPSACK_PRO_CI_NODE_INDEX is not defined on the environment and the CI is not supported', () => {
+      it('throws', () => {
+        expect(() => KnapsackProEnvConfig.ciNodeIndex).toThrow(
+          /Undefined CI node index/,
+        );
+      });
+    });
+
+    describe('when the ciNodeIndex is defined on a supported CI environment', () => {
+      it('returns the ciNodeIndex for the supported CI provider', () => {
+        const ciNodeIndex = '2';
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_PARALLEL_JOB = ciNodeIndex;
+
+        const expected = parseInt(ciNodeIndex, 10);
+        expect(KnapsackProEnvConfig.ciNodeIndex).toEqual(expected);
+      });
+    });
+
+    describe('when KNAPSACK_PRO_CI_NODE_INDEX is defined on the environment AND the ciNodeIndex is defined on a supported CI environment', () => {
+      it('returns KNAPSACK_PRO_CI_NODE_INDEX', () => {
+        const ciNodeIndex = '2';
+        process.env.KNAPSACK_PRO_CI_NODE_INDEX = ciNodeIndex;
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_PARALLEL_JOB = '3';
+
+        const expected = parseInt(ciNodeIndex, 10);
+        expect(KnapsackProEnvConfig.ciNodeIndex).toEqual(expected);
+      });
+    });
+  });
+
+  describe('.commitHash', () => {
+    describe('when the commitHash is defined on a supported CI environment', () => {
+      it('returns the commitHash for the supported CI provider', () => {
+        const commitHash = 'aaa111';
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_COMMIT = commitHash;
+
+        expect(KnapsackProEnvConfig.commitHash).toEqual(commitHash);
+      });
+    });
+
+    describe('when KNAPSACK_PRO_COMMIT_HASH is defined on the environment AND the commitHash is defined on a supported CI environment', () => {
+      it('returns KNAPSACK_PRO_COMMIT_HASH', () => {
+        const commitHash = 'aaa111';
+        process.env.KNAPSACK_PRO_COMMIT_HASH = commitHash;
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_COMMIT = 'bbb222';
+
+        expect(KnapsackProEnvConfig.commitHash).toEqual(commitHash);
+      });
+    });
+  });
+
+  describe('.branch', () => {
+    describe('when the branch is defined on a supported CI environment', () => {
+      it('returns the branch for the supported CI provider', () => {
+        const branch = 'aaa111';
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_BRANCH = branch;
+
+        expect(KnapsackProEnvConfig.branch).toEqual(branch);
+      });
+    });
+
+    describe('when KNAPSACK_PRO_BRANCH is defined on the environment AND the branch is defined on a supported CI environment', () => {
+      it('returns KNAPSACK_PRO_BRANCH', () => {
+        const branch = 'aaa111';
+        process.env.KNAPSACK_PRO_BRANCH = branch;
+        process.env.BUILDKITE = 'true';
+        process.env.BUILDKITE_BRANCH = 'bbb222';
+
+        expect(KnapsackProEnvConfig.branch).toEqual(branch);
+      });
+    });
+  });
+
+  describe('.fixedQueueSplit', () => {
+    let logs: string[] = [];
+
+    beforeEach(() => {
+      // eslint-disable-next-line dot-notation
+      KnapsackProEnvConfig['$knapsackProLogger'] = {
+        info(message) {
+          logs.push(message);
+        },
+      } as KnapsackProLogger;
+    });
+
+    afterEach(() => {
+      // eslint-disable-next-line dot-notation
+      KnapsackProEnvConfig['$fixedQueueSplit'] = undefined;
+      logs = [];
+    });
+
+    describe('when ENV exists', () => {
+      describe('when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=false', () => {
+        const TESTS: [string, object][] = [
+          ['AppVeyor', { APPVEYOR: 'whatever' }],
+          ['Buildkite', { BUILDKITE: 'whatever' }],
+          ['CircleCI', { CIRCLECI: 'whatever' }],
+          ['Cirrus CI', { CIRRUS_CI: 'whatever' }],
+          ['Codefresh', { CF_BUILD_ID: 'whatever' }],
+          ['Codeship', { CI_NAME: 'codeship' }],
+          ['GitHub Actions', { GITHUB_ACTIONS: 'whatever' }],
+          ['GitLab CI', { GITLAB_CI: 'whatever' }],
+          ['Heroku CI', { HEROKU_TEST_RUN_ID: 'whatever' }],
+          ['Semaphore CI 1.0', { SEMAPHORE_BUILD_NUMBER: 'whatever' }],
+          [
+            'Semaphore CI 2.0',
+            { SEMAPHORE: 'whatever', SEMAPHORE_WORKFLOW_ID: 'whatever' },
+          ],
+          ['Travis CI', { TRAVIS: 'whatever' }],
+          ['Unsupported CI', {}],
+        ];
+        TESTS.forEach(([ci, env]) => {
+          it(`on ${ci} it is false`, () => {
+            process.env = { ...process.env, ...env };
+            process.env.KNAPSACK_PRO_FIXED_QUEUE_SPLIT = 'false';
+
+            expect(KnapsackProEnvConfig.fixedQueueSplit).toEqual(false);
+            expect(logs).toEqual([]);
+          });
+        });
+      });
+
+      describe('when KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true', () => {
+        const TESTS: [string, object][] = [
+          ['AppVeyor', { APPVEYOR: 'whatever' }],
+          ['Buildkite', { BUILDKITE: 'whatever' }],
+          ['CircleCI', { CIRCLECI: 'whatever' }],
+          ['Cirrus CI', { CIRRUS_CI: 'whatever' }],
+          ['Codefresh', { CF_BUILD_ID: 'whatever' }],
+          ['Codeship', { CI_NAME: 'codeship' }],
+          ['GitHub Actions', { GITHUB_ACTIONS: 'whatever' }],
+          ['GitLab CI', { GITLAB_CI: 'whatever' }],
+          ['Heroku CI', { HEROKU_TEST_RUN_ID: 'whatever' }],
+          ['Semaphore CI 1.0', { SEMAPHORE_BUILD_NUMBER: 'whatever' }],
+          [
+            'Semaphore CI 2.0',
+            { SEMAPHORE: 'whatever', SEMAPHORE_WORKFLOW_ID: 'whatever' },
+          ],
+          ['Travis CI', { TRAVIS: 'whatever' }],
+          ['Unsupported CI', {}],
+        ];
+        TESTS.forEach(([ci, env]) => {
+          it(`on ${ci} it is true`, () => {
+            process.env = { ...process.env, ...env };
+            process.env.KNAPSACK_PRO_FIXED_QUEUE_SPLIT = 'true';
+
+            expect(KnapsackProEnvConfig.fixedQueueSplit).toEqual(true);
+            expect(logs).toEqual([]);
+          });
+        });
+      });
+    });
+
+    describe("when ENV doesn't exist", () => {
+      const TESTS: [string, object, boolean][] = [
+        ['AppVeyor', { APPVEYOR: 'whatever' }, false],
+        ['Buildkite', { BUILDKITE: 'whatever' }, true],
+        ['CircleCI', { CIRCLECI: 'whatever' }, false],
+        ['Cirrus CI', { CIRRUS_CI: 'whatever' }, false],
+        ['Codefresh', { CF_BUILD_ID: 'whatever' }, false],
+        ['Codeship', { CI_NAME: 'codeship' }, true],
+        ['GitHub Actions', { GITHUB_ACTIONS: 'whatever' }, true],
+        ['GitLab CI', { GITLAB_CI: 'whatever' }, false],
+        ['Heroku CI', { HEROKU_TEST_RUN_ID: 'whatever' }, false],
+        ['Semaphore CI 1.0', { SEMAPHORE_BUILD_NUMBER: 'whatever' }, false],
+        [
+          'Semaphore CI 2.0',
+          { SEMAPHORE: 'whatever', SEMAPHORE_WORKFLOW_ID: 'whatever' },
+          false,
+        ],
+        ['Travis CI', { TRAVIS: 'whatever' }, true],
+        ['Unsupported', {}, true],
+      ];
+      TESTS.forEach(([ci, env, expected]) => {
+        it(`on ${ci} it is ${expected} and the default value is logged once`, () => {
+          process.env = { ...process.env, ...env };
+
+          expect(KnapsackProEnvConfig.fixedQueueSplit).toEqual(expected);
+          // eslint-disable-next-line
+          const _ = KnapsackProEnvConfig.fixedQueueSplit;
+          expect(logs).toEqual([
+            `KNAPSACK_PRO_FIXED_QUEUE_SPLIT is not set. Using default value: ${expected}. Learn more at ${Urls.FIXED_QUEUE_SPLIT}`,
+          ]);
         });
       });
     });

--- a/packages/core/__tests__/test-files-finder.spec.ts
+++ b/packages/core/__tests__/test-files-finder.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import { TestFilesFinder } from '../src/test-files-finder';
 import { TestFile } from '../src/models';
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-prettier": "^4.0.0",
     "gulp": "^4.0.2",
     "gulp-typescript": "^5.0.1",

--- a/packages/core/src/ci-providers/appveyor.ts
+++ b/packages/core/src/ci-providers/appveyor.ts
@@ -2,31 +2,39 @@ import { CIProviderBase } from '.';
 
 // https://www.appveyor.com/docs/environment-variables/
 export class AppVeyor extends CIProviderBase {
-  public static get ciNodeTotal(): void {
+  public static get ciNodeTotal(): undefined {
     return undefined;
   }
 
-  public static get ciNodeIndex(): void {
+  public static get ciNodeIndex(): undefined {
     return undefined;
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.APPVEYOR_BUILD_ID;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.APPVEYOR_REPO_COMMIT;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.APPVEYOR_REPO_BRANCH;
   }
 
-  public static get userSeat(): void {
+  public static get userSeat(): undefined {
     return undefined;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'APPVEYOR' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return false;
   }
 }

--- a/packages/core/src/ci-providers/buildkite.ts
+++ b/packages/core/src/ci-providers/buildkite.ts
@@ -1,33 +1,41 @@
 import { CIProviderBase } from '.';
 
 export class Buildkite extends CIProviderBase {
-  public static get ciNodeTotal(): string | void {
+  public static get ciNodeTotal(): string | undefined {
     return process.env.BUILDKITE_PARALLEL_JOB_COUNT;
   }
 
-  public static get ciNodeIndex(): string | void {
+  public static get ciNodeIndex(): string | undefined {
     return process.env.BUILDKITE_PARALLEL_JOB;
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.BUILDKITE_BUILD_NUMBER;
   }
 
-  public static get ciNodeRetryCount(): string | void {
+  public static get ciNodeRetryCount(): string | undefined {
     return process.env.BUILDKITE_RETRY_COUNT;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.BUILDKITE_COMMIT;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.BUILDKITE_BRANCH;
   }
 
-  public static get userSeat(): string | void {
+  public static get userSeat(): string | undefined {
     return (
       process.env.BUILDKITE_BUILD_AUTHOR || process.env.BUILDKITE_BUILD_CREATOR
     );
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'BUILDKITE' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return true;
   }
 }

--- a/packages/core/src/ci-providers/ci-provider.base.ts
+++ b/packages/core/src/ci-providers/ci-provider.base.ts
@@ -1,29 +1,33 @@
 export abstract class CIProviderBase {
-  public static get ciNodeTotal(): string | void {
+  public static get ciNodeTotal(): string | undefined {
     throw new Error('nodeTotal getter is not implemented!');
   }
 
-  public static get ciNodeIndex(): string | void {
+  public static get ciNodeIndex(): string | undefined {
     throw new Error('nodeIndex getter is not implemented!');
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     throw new Error('nodeBuildId getter is not implemented!');
   }
 
-  public static get ciNodeRetryCount(): string | void {
+  public static get ciNodeRetryCount(): string | undefined {
     throw new Error('ciNodeRetryCount getter is not implemented!');
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     throw new Error('commitHash getter is not implemented!');
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     throw new Error('branch getter is not implemented!');
   }
 
-  public static get userSeat(): string | void {
+  public static get userSeat(): string | undefined {
     throw new Error('userSeat getter is not implemented!');
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    throw new Error('fixedQueueSplit getter is not implemented!');
   }
 }

--- a/packages/core/src/ci-providers/circle-ci.ts
+++ b/packages/core/src/ci-providers/circle-ci.ts
@@ -1,31 +1,39 @@
 import { CIProviderBase } from '.';
 
 export class CircleCI extends CIProviderBase {
-  public static get ciNodeTotal(): string | void {
+  public static get ciNodeTotal(): string | undefined {
     return process.env.CIRCLE_NODE_TOTAL;
   }
 
-  public static get ciNodeIndex(): string | void {
+  public static get ciNodeIndex(): string | undefined {
     return process.env.CIRCLE_NODE_INDEX;
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.CIRCLE_BUILD_NUM;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.CIRCLE_SHA1;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.CIRCLE_BRANCH;
   }
 
-  public static get userSeat(): string | void {
+  public static get userSeat(): string | undefined {
     return process.env.CIRCLE_USERNAME || process.env.CIRCLE_PR_USERNAME;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'CIRCLECI' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return false;
   }
 }

--- a/packages/core/src/ci-providers/cirrus-ci.ts
+++ b/packages/core/src/ci-providers/cirrus-ci.ts
@@ -1,31 +1,39 @@
 import { CIProviderBase } from '.';
 
 export class CirrusCI extends CIProviderBase {
-  public static get ciNodeTotal(): string | void {
+  public static get ciNodeTotal(): string | undefined {
     return process.env.CI_NODE_TOTAL;
   }
 
-  public static get ciNodeIndex(): string | void {
+  public static get ciNodeIndex(): string | undefined {
     return process.env.CI_NODE_INDEX;
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.CIRRUS_BUILD_ID;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.CIRRUS_CHANGE_IN_REPO;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.CIRRUS_BRANCH;
   }
 
-  public static get userSeat(): void {
+  public static get userSeat(): undefined {
     return undefined;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'CIRRUS_CI' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return false;
   }
 }

--- a/packages/core/src/ci-providers/codefresh-ci.ts
+++ b/packages/core/src/ci-providers/codefresh-ci.ts
@@ -2,31 +2,39 @@ import { CIProviderBase } from '.';
 
 // https://codefresh.io/docs/docs/codefresh-yaml/variables/#system-provided-variables
 export class CodefreshCI extends CIProviderBase {
-  public static get ciNodeTotal(): void {
+  public static get ciNodeTotal(): undefined {
     return undefined;
   }
 
-  public static get ciNodeIndex(): void {
+  public static get ciNodeIndex(): undefined {
     return undefined;
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.CF_BUILD_ID;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.CF_REVISION;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.CF_BRANCH;
   }
 
-  public static get userSeat(): void {
+  public static get userSeat(): undefined {
     return undefined;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'CF_BUILD_ID' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return false;
   }
 }

--- a/packages/core/src/ci-providers/codeship.ts
+++ b/packages/core/src/ci-providers/codeship.ts
@@ -1,31 +1,39 @@
 import { CIProviderBase } from '.';
 
 export class Codeship extends CIProviderBase {
-  public static get ciNodeTotal(): void {
+  public static get ciNodeTotal(): undefined {
     return undefined;
   }
 
-  public static get ciNodeIndex(): void {
+  public static get ciNodeIndex(): undefined {
     return undefined;
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.CI_BUILD_NUMBER;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.CI_COMMIT_ID;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.CI_BRANCH;
   }
 
-  public static get userSeat(): void {
+  public static get userSeat(): undefined {
     return undefined;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return process.env.CI_NAME === 'codeship' ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return true;
   }
 }

--- a/packages/core/src/ci-providers/github-actions.ts
+++ b/packages/core/src/ci-providers/github-actions.ts
@@ -2,21 +2,21 @@ import { CIProviderBase } from '.';
 
 // https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
 export class GithubActions extends CIProviderBase {
-  public static get ciNodeTotal(): void {
+  public static get ciNodeTotal(): undefined {
     return undefined;
   }
 
-  public static get ciNodeIndex(): void {
+  public static get ciNodeIndex(): undefined {
     return undefined;
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     // A unique number for each run within a repository.
     // This number does not change if you re-run the workflow run.
     return process.env.GITHUB_RUN_ID;
   }
 
-  public static get ciNodeRetryCount(): string | void {
+  public static get ciNodeRetryCount(): string | undefined {
     // A unique number for each attempt of a particular workflow run in a repository.
     // This number begins at 1 for the workflow run's first attempt, and increments with each re-run.
     const runAttempt = process.env.GITHUB_RUN_ATTEMPT;
@@ -29,18 +29,26 @@ export class GithubActions extends CIProviderBase {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.GITHUB_SHA;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     // GITHUB_REF - The branch or tag ref that triggered the workflow.
     // For example, refs/heads/feature-branch-1.
     // If neither a branch or tag is available for the event type, the variable will not exist.
     return process.env.GITHUB_REF || process.env.GITHUB_SHA;
   }
 
-  public static get userSeat(): string | void {
+  public static get userSeat(): string | undefined {
     return process.env.GITHUB_ACTOR;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'GITHUB_ACTIONS' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return true;
   }
 }

--- a/packages/core/src/ci-providers/gitlab-ci.ts
+++ b/packages/core/src/ci-providers/gitlab-ci.ts
@@ -1,12 +1,12 @@
 import { CIProviderBase } from '.';
 
 export class GitlabCI extends CIProviderBase {
-  public static get ciNodeTotal(): string | void {
+  public static get ciNodeTotal(): string | undefined {
     return process.env.CI_NODE_TOTAL;
   }
 
   // eslint-disable-next-line getter-return, consistent-return
-  public static get ciNodeIndex(): string | void {
+  public static get ciNodeIndex(): string | undefined {
     if (process.env.GITLAB_CI) {
       const index = process.env.CI_NODE_INDEX; // GitLab >= 11.5
 
@@ -16,28 +16,36 @@ export class GitlabCI extends CIProviderBase {
     }
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     // GitLab Release 9.0+ || GitLab Release 8.x
     return process.env.CI_PIPELINE_ID || process.env.CI_BUILD_ID;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     // GitLab Release 9.0+ || GitLab Release 8.x
     return process.env.CI_COMMIT_SHA || process.env.CI_BUILD_REF;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     // GitLab Release 9.0+ || GitLab Release 8.x
     return process.env.CI_COMMIT_REF_NAME || process.env.CI_BUILD_REF_NAME;
   }
 
-  public static get userSeat(): string | void {
+  public static get userSeat(): string | undefined {
     const userName = process.env.GITLAB_USER_NAME; // Gitlab Release 10.0
     const userEmail = process.env.GITLAB_USER_EMAIL; // Gitlab Release 8.12
     return userName || userEmail;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'GITLAB_CI' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return false;
   }
 }

--- a/packages/core/src/ci-providers/heroku-ci.ts
+++ b/packages/core/src/ci-providers/heroku-ci.ts
@@ -1,31 +1,39 @@
 import { CIProviderBase } from '.';
 
 export class HerokuCI extends CIProviderBase {
-  public static get ciNodeTotal(): string | void {
+  public static get ciNodeTotal(): string | undefined {
     return process.env.CI_NODE_TOTAL;
   }
 
-  public static get ciNodeIndex(): string | void {
+  public static get ciNodeIndex(): string | undefined {
     return process.env.CI_NODE_INDEX;
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.HEROKU_TEST_RUN_ID;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.HEROKU_TEST_RUN_COMMIT_VERSION;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.HEROKU_TEST_RUN_BRANCH;
   }
 
-  public static get userSeat(): void {
+  public static get userSeat(): undefined {
     return undefined;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'HEROKU_TEST_RUN_ID' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return false;
   }
 }

--- a/packages/core/src/ci-providers/index.ts
+++ b/packages/core/src/ci-providers/index.ts
@@ -1,4 +1,5 @@
 export * from './ci-provider.base';
+
 export * from './appveyor';
 export * from './buildkite';
 export * from './circle-ci';
@@ -11,3 +12,4 @@ export * from './heroku-ci';
 export * from './semaphore-ci';
 export * from './semaphore-ci-2';
 export * from './travis-ci';
+export * from './unsupported-ci';

--- a/packages/core/src/ci-providers/semaphore-ci-2.ts
+++ b/packages/core/src/ci-providers/semaphore-ci-2.ts
@@ -1,12 +1,12 @@
 import { CIProviderBase } from '.';
 
 export class SemaphoreCI2 extends CIProviderBase {
-  public static get ciNodeTotal(): string | void {
+  public static get ciNodeTotal(): string | undefined {
     return process.env.SEMAPHORE_JOB_COUNT;
   }
 
   // eslint-disable-next-line getter-return, consistent-return
-  public static get ciNodeIndex(): string | void {
+  public static get ciNodeIndex(): string | undefined {
     const jobIndex = process.env.SEMAPHORE_JOB_INDEX;
 
     if (jobIndex) {
@@ -14,23 +14,33 @@ export class SemaphoreCI2 extends CIProviderBase {
     }
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.SEMAPHORE_WORKFLOW_ID;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.SEMAPHORE_GIT_SHA;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.SEMAPHORE_GIT_BRANCH;
   }
 
-  public static get userSeat(): void {
+  public static get userSeat(): undefined {
     return undefined;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'SEMAPHORE' in process.env && 'SEMAPHORE_WORKFLOW_ID' in process.env
+      ? this
+      : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return false;
   }
 }

--- a/packages/core/src/ci-providers/semaphore-ci.ts
+++ b/packages/core/src/ci-providers/semaphore-ci.ts
@@ -1,12 +1,12 @@
 import { CIProviderBase } from '.';
 
 export class SemaphoreCI extends CIProviderBase {
-  public static get ciNodeTotal(): string | void {
+  public static get ciNodeTotal(): string | undefined {
     return process.env.SEMAPHORE_THREAD_COUNT;
   }
 
   // eslint-disable-next-line getter-return, consistent-return
-  public static get ciNodeIndex(): string | void {
+  public static get ciNodeIndex(): string | undefined {
     const currentThread = process.env.SEMAPHORE_CURRENT_THREAD;
 
     if (currentThread) {
@@ -14,23 +14,31 @@ export class SemaphoreCI extends CIProviderBase {
     }
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.SEMAPHORE_BUILD_NUMBER;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.REVISION;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.BRANCH_NAME;
   }
 
-  public static get userSeat(): void {
+  public static get userSeat(): undefined {
     return undefined;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'SEMAPHORE_BUILD_NUMBER' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return false;
   }
 }

--- a/packages/core/src/ci-providers/travis-ci.ts
+++ b/packages/core/src/ci-providers/travis-ci.ts
@@ -1,31 +1,39 @@
 import { CIProviderBase } from '.';
 
 export class TravisCI extends CIProviderBase {
-  public static get ciNodeTotal(): void {
+  public static get ciNodeTotal(): undefined {
     return undefined;
   }
 
-  public static get ciNodeIndex(): void {
+  public static get ciNodeIndex(): undefined {
     return undefined;
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return process.env.TRAVIS_BUILD_NUMBER;
   }
 
-  public static get ciNodeRetryCount(): void {
+  public static get ciNodeRetryCount(): undefined {
     return undefined;
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return process.env.TRAVIS_COMMIT;
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return process.env.TRAVIS_BRANCH;
   }
 
-  public static get userSeat(): void {
+  public static get userSeat(): undefined {
     return undefined;
+  }
+
+  public static get detect(): typeof CIProviderBase | null {
+    return 'TRAVIS' in process.env ? this : null;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return true;
   }
 }

--- a/packages/core/src/ci-providers/unsupported-ci.ts
+++ b/packages/core/src/ci-providers/unsupported-ci.ts
@@ -1,0 +1,33 @@
+export abstract class UnsupportedCI {
+  public static get ciNodeTotal(): string | undefined {
+    return undefined;
+  }
+
+  public static get ciNodeIndex(): string | undefined {
+    return undefined;
+  }
+
+  public static get ciNodeBuildId(): string | undefined {
+    return undefined;
+  }
+
+  public static get ciNodeRetryCount(): string | undefined {
+    return undefined;
+  }
+
+  public static get commitHash(): string | undefined {
+    return undefined;
+  }
+
+  public static get branch(): string | undefined {
+    return undefined;
+  }
+
+  public static get userSeat(): string | undefined {
+    return undefined;
+  }
+
+  public static get fixedQueueSplit(): boolean {
+    return true;
+  }
+}

--- a/packages/core/src/config/ci-env.config.ts
+++ b/packages/core/src/config/ci-env.config.ts
@@ -1,6 +1,7 @@
 import {
   AppVeyor,
   Buildkite,
+  CIProviderBase,
   CircleCI,
   CirrusCI,
   CodefreshCI,
@@ -12,6 +13,15 @@ import {
   SemaphoreCI2,
   TravisCI,
 } from '../ci-providers';
+
+type CIProviderMethod =
+  | 'ciNodeTotal'
+  | 'ciNodeIndex'
+  | 'ciNodeBuildId'
+  | 'ciNodeRetryCount'
+  | 'commitHash'
+  | 'branch'
+  | 'userSeat';
 
 export class CIEnvConfig {
   public static get ciNodeTotal(): string | void {
@@ -43,9 +53,8 @@ export class CIEnvConfig {
   }
 
   // eslint-disable-next-line consistent-return
-  private static ciEnvFor(functionName: string): string | void {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const supportedCIProviders: any[] = [
+  private static ciEnvFor(functionName: CIProviderMethod): string | void {
+    const supportedCIProviders: (typeof CIProviderBase)[] = [
       // load GitLab CI first to avoid edge case with order of loading envs for CI_NODE_INDEX
       GitlabCI,
       AppVeyor,

--- a/packages/core/src/config/ci-env.config.ts
+++ b/packages/core/src/config/ci-env.config.ts
@@ -12,6 +12,7 @@ import {
   SemaphoreCI,
   SemaphoreCI2,
   TravisCI,
+  UnsupportedCI,
 } from '../ci-providers';
 
 type CIProviderMethod =
@@ -21,42 +22,50 @@ type CIProviderMethod =
   | 'ciNodeRetryCount'
   | 'commitHash'
   | 'branch'
-  | 'userSeat';
+  | 'userSeat'
+  | 'fixedQueueSplit';
 
 export class CIEnvConfig {
-  public static get ciNodeTotal(): string | void {
+  public static get ciNodeTotal(): string | undefined {
     return this.ciEnvFor('ciNodeTotal');
   }
 
-  public static get ciNodeIndex(): string | void {
+  public static get ciNodeIndex(): string | undefined {
     return this.ciEnvFor('ciNodeIndex');
   }
 
-  public static get ciNodeBuildId(): string | void {
+  public static get ciNodeBuildId(): string | undefined {
     return this.ciEnvFor('ciNodeBuildId');
   }
 
-  public static get ciNodeRetryCount(): string | void {
+  public static get ciNodeRetryCount(): string | undefined {
     return this.ciEnvFor('ciNodeRetryCount');
   }
 
-  public static get commitHash(): string | void {
+  public static get commitHash(): string | undefined {
     return this.ciEnvFor('commitHash');
   }
 
-  public static get branch(): string | void {
+  public static get branch(): string | undefined {
     return this.ciEnvFor('branch');
   }
 
-  public static get userSeat(): string | void {
+  public static get userSeat(): string | undefined {
     return this.ciEnvFor('userSeat');
   }
 
-  // eslint-disable-next-line consistent-return
-  private static ciEnvFor(functionName: CIProviderMethod): string | void {
-    const supportedCIProviders: (typeof CIProviderBase)[] = [
-      // load GitLab CI first to avoid edge case with order of loading envs for CI_NODE_INDEX
-      GitlabCI,
+  public static get fixedQueueSplit(): boolean {
+    return this.ciEnvFor('fixedQueueSplit');
+  }
+
+  private static ciEnvFor<T extends CIProviderMethod>(
+    functionName: T,
+  ): (typeof CIProviderBase)[T] {
+    return this.detectCi()[functionName];
+  }
+
+  public static detectCi() {
+    const detected = [
       AppVeyor,
       Buildkite,
       CircleCI,
@@ -64,18 +73,15 @@ export class CIEnvConfig {
       CodefreshCI,
       Codeship,
       GithubActions,
+      GitlabCI,
       HerokuCI,
       SemaphoreCI,
       SemaphoreCI2,
       TravisCI,
-    ];
+    ]
+      .map((provider) => provider.detect)
+      .filter(Boolean)[0];
 
-    // eslint-disable-next-line no-restricted-syntax
-    for (const ciProvider of supportedCIProviders) {
-      const value = ciProvider[functionName];
-      if (value) {
-        return value;
-      }
-    }
+    return detected || UnsupportedCI;
   }
 }

--- a/packages/core/src/config/knapsack-pro-env.config.ts
+++ b/packages/core/src/config/knapsack-pro-env.config.ts
@@ -17,6 +17,10 @@ function logLevel(): string {
 const knapsackProLogger = new KnapsackProLogger(logLevel());
 
 export class KnapsackProEnvConfig {
+  private static $fixedQueueSplit: boolean | undefined;
+
+  private static $knapsackProLogger: KnapsackProLogger = knapsackProLogger;
+
   public static get endpoint(): string {
     if (process.env.KNAPSACK_PRO_ENDPOINT) {
       return process.env.KNAPSACK_PRO_ENDPOINT;
@@ -37,13 +41,32 @@ export class KnapsackProEnvConfig {
   }
 
   public static get fixedQueueSplit(): boolean {
-    if (process.env.KNAPSACK_PRO_FIXED_QUEUE_SPLIT) {
-      return (
-        process.env.KNAPSACK_PRO_FIXED_QUEUE_SPLIT.toLowerCase() === 'true'
+    if (this.$fixedQueueSplit !== undefined) {
+      return this.$fixedQueueSplit;
+    }
+
+    this.$fixedQueueSplit =
+      this.parseBoolean(process.env.KNAPSACK_PRO_FIXED_QUEUE_SPLIT) ??
+      CIEnvConfig.fixedQueueSplit;
+
+    if (!('KNAPSACK_PRO_FIXED_QUEUE_SPLIT' in process.env)) {
+      this.$knapsackProLogger.info(
+        `KNAPSACK_PRO_FIXED_QUEUE_SPLIT is not set. Using default value: ${this.$fixedQueueSplit}. Learn more at ${Urls.FIXED_QUEUE_SPLIT}`,
       );
     }
 
-    return false;
+    return this.$fixedQueueSplit;
+  }
+
+  private static parseBoolean(value: string | undefined): boolean | null {
+    switch (value?.toLowerCase()) {
+      case 'true':
+        return true;
+      case 'false':
+        return false;
+      default:
+        return null;
+    }
   }
 
   public static get ciNodeTotal(): number | never {

--- a/packages/core/src/urls.ts
+++ b/packages/core/src/urls.ts
@@ -2,3 +2,5 @@ export const KNAPSACK_PRO_CI_NODE_BUILD_ID =
   'https://knapsackpro.com/perma/js/knapsack-pro-ci-node-build-id';
 export const QUEUE_MODE_CONNECTION_ERROR_AND_POSITIVE_RETRY_COUNT =
   'https://knapsackpro.com/perma/js/queue-mode-connection-error-and-positive-retry-count';
+export const FIXED_QUEUE_SPLIT =
+  'https://knapsackpro.com/perma/js/fixed-queue-split';


### PR DESCRIPTION
- Detect CI from environment and get the correct ENVs instead of trying all of them and risk conflicts
- Use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` as default value in Queue Mode and use false for proper CI providers

Inspired by:
- https://github.com/KnapsackPro/knapsack_pro-ruby/pull/201
- https://github.com/KnapsackPro/knapsack_pro-ruby/pull/198