### PR TITLE
deps(cypress): update @knapsack-pro/core to 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15450,7 +15450,7 @@
       "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
-        "@knapsack-pro/core": "^6.0.0",
+        "@knapsack-pro/core": "^6.1.0",
         "glob": "^8.1.0",
         "minimatch": "^5.1.4",
         "minimist": "^1.2.6",
@@ -15542,7 +15542,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@knapsack-pro/jest": "^7.0.0",
+        "@knapsack-pro/jest": "^7.1.0",
         "jest": "^29.4.3"
       }
     },
@@ -20310,7 +20310,7 @@
         "@babel/core": "^7.18.2",
         "@babel/preset-env": "^7.18.2",
         "@babel/register": "^7.17.7",
-        "@knapsack-pro/core": "^6.0.0",
+        "@knapsack-pro/core": "^6.1.0",
         "@types/glob": "^8.0.0",
         "@types/jquery": "^3.5.14",
         "@types/node": "^17.0.41",
@@ -21475,7 +21475,7 @@
     "@knapsack-pro/jest-example-test-suite": {
       "version": "file:packages/jest-example-test-suite",
       "requires": {
-        "@knapsack-pro/jest": "^7.0.0",
+        "@knapsack-pro/jest": "^7.1.0",
         "jest": "^29.4.3"
       },
       "dependencies": {

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -58,7 +58,7 @@
     "knapsack-pro-cypress": "lib/knapsack-pro-cypress.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^6.0.0",
+    "@knapsack-pro/core": "^6.1.0",
     "glob": "^8.1.0",
     "minimatch": "^5.1.4",
     "minimist": "^1.2.6",


### PR DESCRIPTION
<!-- Please tag with the correct @knapsack-pro/PACKAGE  label -->
* https://github.com/KnapsackPro/knapsack-pro-js/pull/6