### PR TITLE
Use KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true as default value in Queue Mode for GitLab CI

### DIFF
--- a/.changeset/fast-ways-compete.md
+++ b/.changeset/fast-ways-compete.md
@@ -1,0 +1,5 @@
+---
+"@knapsack-pro/core": patch
+---
+
+Use `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` as default value in Queue Mode for GitLab CI

--- a/packages/core/__tests__/knapsack-pro-env.config.spec.ts
+++ b/packages/core/__tests__/knapsack-pro-env.config.spec.ts
@@ -271,7 +271,7 @@ describe('KnapsackProEnvConfig', () => {
         ['Codefresh', { CF_BUILD_ID: 'whatever' }, false],
         ['Codeship', { CI_NAME: 'codeship' }, true],
         ['GitHub Actions', { GITHUB_ACTIONS: 'whatever' }, true],
-        ['GitLab CI', { GITLAB_CI: 'whatever' }, false],
+        ['GitLab CI', { GITLAB_CI: 'whatever' }, true],
         ['Heroku CI', { HEROKU_TEST_RUN_ID: 'whatever' }, false],
         ['Semaphore CI 1.0', { SEMAPHORE_BUILD_NUMBER: 'whatever' }, false],
         [

--- a/packages/core/src/ci-providers/gitlab-ci.ts
+++ b/packages/core/src/ci-providers/gitlab-ci.ts
@@ -46,6 +46,6 @@ export class GitlabCI extends CIProviderBase {
   }
 
   public static get fixedQueueSplit(): boolean {
-    return false;
+    return true;
   }
 }


### PR DESCRIPTION
Since GitLab CI allows retrying single jobs, `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` should be the default.

Should have been done in https://github.com/KnapsackPro/knapsack-pro-js/pull/3

---

I'm test driving https://github.com/changesets/changesets as a replacement for github_changelog_generator in this PR. Will update READMEs if it turns out to be a good fit.