### PR TITLE
Send authors to api

### DIFF
--- a/.changeset/silver-crabs-travel.md
+++ b/.changeset/silver-crabs-travel.md
@@ -1,0 +1,5 @@
+---
+"@knapsack-pro/core": minor
+---
+
+Send authors to the API

--- a/packages/core/__tests__/ci-env.config.spec.ts
+++ b/packages/core/__tests__/ci-env.config.spec.ts
@@ -14,18 +14,19 @@ import {
   TravisCI,
   UnsupportedCI,
 } from '../src/ci-providers';
-import { CIEnvConfig } from '../src/config/ci-env.config';
+import { isCI, detectCI } from '../src/config/ci-env.config';
 
 describe('KnapsackProEnvConfig', () => {
   // Since we use CircleCI for testing, we prevent it from interfering with the tests.
   delete process.env.CIRCLECI;
+  delete process.env.CI;
   const ENV = { ...process.env };
 
   afterEach(() => {
     process.env = { ...ENV };
   });
 
-  describe('.detectCi', () => {
+  describe('detectCI', () => {
     const TESTS: [string, object, typeof CIProviderBase][] = [
       ['AppVeyor', { APPVEYOR: 'whatever' }, AppVeyor],
       ['Buildkite', { BUILDKITE: 'whatever' }, Buildkite],
@@ -50,7 +51,22 @@ describe('KnapsackProEnvConfig', () => {
       it(`detects ${ci}`, () => {
         process.env = { ...process.env, ...env };
 
-        expect(CIEnvConfig.detectCi()).toEqual(expected);
+        expect(detectCI()).toEqual(expected);
+      });
+    });
+  });
+
+  describe('isCI', () => {
+    const TESTS: [string, object, boolean][] = [
+      ['CI from env', { CI: 'True' }, true],
+      ['AppVeyor', { APPVEYOR: 'whatever' }, true],
+      ['Unsupported CI', {}, false],
+    ];
+    TESTS.forEach(([ci, env, expected]) => {
+      it(`detects ${ci}`, () => {
+        process.env = { ...process.env, ...env };
+
+        expect(isCI()).toEqual(expected);
       });
     });
   });

--- a/packages/core/src/ci-providers/unsupported-ci.ts
+++ b/packages/core/src/ci-providers/unsupported-ci.ts
@@ -1,4 +1,6 @@
-export abstract class UnsupportedCI {
+import { CIProviderBase } from '.';
+
+export class UnsupportedCI extends CIProviderBase {
   public static get ciNodeTotal(): string | undefined {
     return undefined;
   }

--- a/packages/core/src/config/ci-env.config.ts
+++ b/packages/core/src/config/ci-env.config.ts
@@ -15,6 +15,31 @@ import {
   UnsupportedCI,
 } from '../ci-providers';
 
+export const detectCI = (): typeof CIProviderBase => {
+  const detected = [
+    AppVeyor,
+    Buildkite,
+    CircleCI,
+    CirrusCI,
+    CodefreshCI,
+    Codeship,
+    GithubActions,
+    GitlabCI,
+    HerokuCI,
+    SemaphoreCI,
+    SemaphoreCI2,
+    TravisCI,
+  ]
+    .map((provider) => provider.detect)
+    .filter(Boolean)[0];
+
+  return detected || UnsupportedCI;
+};
+
+export const isCI = (): boolean =>
+  (process.env.CI || 'false').toLowerCase() === 'true' ||
+  detectCI() !== UnsupportedCI;
+
 type CIProviderMethod =
   | 'ciNodeTotal'
   | 'ciNodeIndex'
@@ -61,27 +86,6 @@ export class CIEnvConfig {
   private static ciEnvFor<T extends CIProviderMethod>(
     functionName: T,
   ): (typeof CIProviderBase)[T] {
-    return this.detectCi()[functionName];
-  }
-
-  public static detectCi() {
-    const detected = [
-      AppVeyor,
-      Buildkite,
-      CircleCI,
-      CirrusCI,
-      CodefreshCI,
-      Codeship,
-      GithubActions,
-      GitlabCI,
-      HerokuCI,
-      SemaphoreCI,
-      SemaphoreCI2,
-      TravisCI,
-    ]
-      .map((provider) => provider.detect)
-      .filter(Boolean)[0];
-
-    return detected || UnsupportedCI;
+    return detectCI()[functionName];
   }
 }

--- a/packages/core/src/knapsack-pro-api.ts
+++ b/packages/core/src/knapsack-pro-api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError, AxiosInstance, AxiosPromise } from 'axios';
 
-import { KnapsackProEnvConfig } from './config';
+import { KnapsackProEnvConfig, buildAuthor, commitAuthors } from './config';
 import { KnapsackProLogger } from './knapsack-pro-logger';
 import { TestFile } from './models';
 
@@ -28,8 +28,6 @@ export class KnapsackProAPI {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): AxiosPromise<any> {
     const url = '/v1/queues/queue';
-    const shouldSendTestFilesInPayload =
-      initializeQueue && !attemptConnectToQueue;
     const data = {
       test_suite_token: KnapsackProEnvConfig.testSuiteToken,
       can_initialize_queue: initializeQueue,
@@ -41,7 +39,12 @@ export class KnapsackProAPI {
       node_index: KnapsackProEnvConfig.ciNodeIndex,
       node_build_id: KnapsackProEnvConfig.ciNodeBuildId,
       user_seat: KnapsackProEnvConfig.maskedUserSeat,
-      ...(shouldSendTestFilesInPayload && { test_files: allTestFiles }),
+      ...(initializeQueue &&
+        !attemptConnectToQueue && {
+          test_files: allTestFiles,
+          build_author: buildAuthor(),
+          commit_authors: commitAuthors(),
+        }),
     };
 
     return this.api.post(url, data);


### PR DESCRIPTION
To test the command in the REPL, you can:

```bash
node
var execSync = require('child_process').execSync;
execSync('echo 123').toString()
```

This applies similar changes to the ones for Ruby: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/208