### PR TITLE
Fix hanging CI when `git fetch --shallow-since` takes too long

### DIFF
--- a/.changeset/nine-bugs-press.md
+++ b/.changeset/nine-bugs-press.md
@@ -1,5 +1,5 @@
 ---
-"@knapsack-pro/core": minor
+"@knapsack-pro/core": patch
 ---
 
 Fix hanging CI when `git fetch --shallow-since` takes too long

--- a/.changeset/nine-bugs-press.md
+++ b/.changeset/nine-bugs-press.md
@@ -1,0 +1,7 @@
+---
+"@knapsack-pro/core": minor
+---
+
+Fix hanging CI when `git fetch --shallow-since` takes too long
+
+https://github.com/KnapsackPro/knapsack-pro-js/pull/48

--- a/packages/core/src/config/knapsack-pro-env.config.ts
+++ b/packages/core/src/config/knapsack-pro-env.config.ts
@@ -276,6 +276,7 @@ const $commitAuthors = (
 
 const gitCommitAuthors = () => {
   if (isCI && isShallowRepository()) {
+    execSync(`git fetch --shallow-since "one month ago" --quiet 2>/dev/null`);
   }
 
   return execSync(

--- a/packages/core/src/config/knapsack-pro-env.config.ts
+++ b/packages/core/src/config/knapsack-pro-env.config.ts
@@ -275,36 +275,19 @@ const $commitAuthors = (
 };
 
 const gitCommitAuthors = () => {
-  // if (isCI && isShallowRepository()) {
-  if (isCI) {
-    knapsackProLogger.error('2XXXXXXXXXXXX');
-    // execSync(`git fetch --shallow-since "one month ago" --quiet 2>/dev/null`);
-    // const command =
-    //   'git fetch --shallow-since "one month ago" --quiet 2>/dev/null';
-    const command = 'sleep 6';
-    knapsackProLogger.error('start command');
-    const gitFetchShallowProcess = spawnSync(command, { shell: true });
-    knapsackProLogger.error('after started the command');
+  if (isCI && isShallowRepository()) {
+    const gitFetchShallowSinceCommand =
+      'git fetch --shallow-since "one month ago" --quiet 2>/dev/null';
 
-    const timeout = setTimeout(() => {
-      if (gitFetchShallowProcess && gitFetchShallowProcess.pid) {
-        process.kill(gitFetchShallowProcess.pid);
-        console.log('KILLLLLLL');
-        knapsackProLogger.error(
-          `Skip the \`${command}\` command because it took too long.`,
-        );
-      }
-    }, 2000);
-    knapsackProLogger.error('after timeout set');
-
-    // Wait for the process to complete
-    const result =
-      gitFetchShallowProcess.status === 0
-        ? gitFetchShallowProcess.stdout
-        : gitFetchShallowProcess.stderr;
-
-    // Clear the timeout to prevent the cancellation
-    clearTimeout(timeout);
+    try {
+      execSync(gitFetchShallowSinceCommand, {
+        timeout: 5000,
+      });
+    } catch (error) {
+      knapsackProLogger.debug(
+        `Skip the \`${gitFetchShallowSinceCommand}\` command because it took too long. Error: ${error.message}`,
+      );
+    }
   }
 
   return execSync(

--- a/packages/core/src/config/knapsack-pro-env.config.ts
+++ b/packages/core/src/config/knapsack-pro-env.config.ts
@@ -245,6 +245,16 @@ const gitBuildAuthor = () =>
 export const buildAuthor = (command = gitBuildAuthor): string =>
   $buildAuthor(command);
 
+const gitIsShallowRepository = () =>
+  execSync(`git rev-parse --is-shallow-repository 2>/dev/null`);
+
+const $isShallowRepository = (command: () => Buffer): boolean =>
+  command().toString().trim() === 'true';
+
+export const isShallowRepository = (
+  command = gitIsShallowRepository,
+): boolean => $isShallowRepository(command);
+
 const $commitAuthors = (
   command: () => Buffer,
 ): { commits: number; author: string }[] => {
@@ -265,8 +275,7 @@ const $commitAuthors = (
 };
 
 const gitCommitAuthors = () => {
-  if (isCI) {
-    execSync(`git fetch --shallow-since "one month ago" --quiet 2>/dev/null`);
+  if (isCI && isShallowRepository) {
   }
 
   return execSync(

--- a/packages/core/src/config/knapsack-pro-env.config.ts
+++ b/packages/core/src/config/knapsack-pro-env.config.ts
@@ -275,7 +275,7 @@ const $commitAuthors = (
 };
 
 const gitCommitAuthors = () => {
-  if (isCI && isShallowRepository) {
+  if (isCI && isShallowRepository()) {
   }
 
   return execSync(

--- a/packages/core/src/config/knapsack-pro-env.config.ts
+++ b/packages/core/src/config/knapsack-pro-env.config.ts
@@ -275,8 +275,36 @@ const $commitAuthors = (
 };
 
 const gitCommitAuthors = () => {
-  if (isCI && isShallowRepository()) {
-    execSync(`git fetch --shallow-since "one month ago" --quiet 2>/dev/null`);
+  // if (isCI && isShallowRepository()) {
+  if (isCI) {
+    knapsackProLogger.error('2XXXXXXXXXXXX');
+    // execSync(`git fetch --shallow-since "one month ago" --quiet 2>/dev/null`);
+    // const command =
+    //   'git fetch --shallow-since "one month ago" --quiet 2>/dev/null';
+    const command = 'sleep 6';
+    knapsackProLogger.error('start command');
+    const gitFetchShallowProcess = spawnSync(command, { shell: true });
+    knapsackProLogger.error('after started the command');
+
+    const timeout = setTimeout(() => {
+      if (gitFetchShallowProcess && gitFetchShallowProcess.pid) {
+        process.kill(gitFetchShallowProcess.pid);
+        console.log('KILLLLLLL');
+        knapsackProLogger.error(
+          `Skip the \`${command}\` command because it took too long.`,
+        );
+      }
+    }, 2000);
+    knapsackProLogger.error('after timeout set');
+
+    // Wait for the process to complete
+    const result =
+      gitFetchShallowProcess.status === 0
+        ? gitFetchShallowProcess.stdout
+        : gitFetchShallowProcess.stderr;
+
+    // Clear the timeout to prevent the cancellation
+    clearTimeout(timeout);
   }
 
   return execSync(

--- a/packages/jest-example-test-suite/bin/knapsack_pro_jest_record_first_run
+++ b/packages/jest-example-test-suite/bin/knapsack_pro_jest_record_first_run
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# How to run this script in the loop
+# while bin/knapsack_pro_jest_initialize_new_queue; do :; done
+
+CI_BUILD_ID=$(openssl rand -base64 32)
+COMMIT_HASH=$(openssl rand -hex 20)
+BRANCH=fake-branch/initialize-new-queue
+
+echo 'CI build for a commit:'
+echo $COMMIT_HASH
+
+ENDPOINT=https://api-staging.knapsackpro.com
+# ENDPOINT=http://api.knapsackpro.test:3000
+
+LOG_LEVEL=info
+# LOG_LEVEL=debug
+
+export KNAPSACK_PRO_ENDPOINT=$ENDPOINT
+export KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=cd67ffc01ce2b3d56f3a223b547f466e
+export KNAPSACK_PRO_TEST_FILE_PATTERN=$TEST_FILE_PATTERN
+export KNAPSACK_PRO_LOG_LEVEL=$LOG_LEVEL
+export KNAPSACK_PRO_CI_NODE_BUILD_ID=$CI_BUILD_ID
+export KNAPSACK_PRO_CI_NODE_TOTAL=2
+export KNAPSACK_PRO_COMMIT_HASH=$COMMIT_HASH
+export KNAPSACK_PRO_BRANCH=$BRANCH
+
+KNAPSACK_PRO_CI_NODE_INDEX=0 \
+  npx @knapsack-pro/jest --runInBand

--- a/packages/jest-example-test-suite/bin/knapsack_pro_jest_record_first_run
+++ b/packages/jest-example-test-suite/bin/knapsack_pro_jest_record_first_run
@@ -13,8 +13,8 @@ echo $COMMIT_HASH
 ENDPOINT=https://api-staging.knapsackpro.com
 # ENDPOINT=http://api.knapsackpro.test:3000
 
-LOG_LEVEL=info
-# LOG_LEVEL=debug
+# LOG_LEVEL=info
+LOG_LEVEL=debug
 
 export KNAPSACK_PRO_ENDPOINT=$ENDPOINT
 export KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=cd67ffc01ce2b3d56f3a223b547f466e


### PR DESCRIPTION
<!-- Please tag with the correct @knapsack-pro/PACKAGE  label -->

# changes

* Call `git fetch --shallow-since "one month ago" --quiet 2>/dev/null` only if the repository is shallow
* Skip `git fetch --shallow-since` when it takes longer than 5s
 
# related

* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/212