### PR TITLE
Send CI provider to API

### DIFF
--- a/.changeset/silver-walls-call.md
+++ b/.changeset/silver-walls-call.md
@@ -1,0 +1,5 @@
+---
+"@knapsack-pro/core": patch
+---
+
+Fix isCi() check when computing commitAuthors

--- a/.changeset/spotty-mails-do.md
+++ b/.changeset/spotty-mails-do.md
@@ -1,0 +1,5 @@
+---
+"@knapsack-pro/core": minor
+---
+
+Send to the API the CI provider with a header

--- a/packages/core/__tests__/knapsack-pro-api.spec.ts
+++ b/packages/core/__tests__/knapsack-pro-api.spec.ts
@@ -1,0 +1,48 @@
+import { getHeaders } from '../src/knapsack-pro-api';
+
+describe('KnapsackProAPI', () => {
+  // Since we use CircleCI for testing, we prevent it from interfering with the tests.
+  delete process.env.CIRCLECI;
+  delete process.env.CI;
+  const ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ENV };
+  });
+
+  describe('getHeaders', () => {
+    it('includes KNAPSACK-PRO-CLIENT-NAME', () => {
+      const clientName = '@knapsack-pro/jest';
+
+      const actual = getHeaders({ clientName, clientVersion: '' })[
+        'KNAPSACK-PRO-CLIENT-NAME'
+      ];
+
+      expect(actual).toEqual(clientName);
+    });
+
+    it('includes KNAPSACK-PRO-CLIENT-VERSION', () => {
+      const clientVersion = '7.2.1';
+
+      const actual = getHeaders({ clientName: '', clientVersion })[
+        'KNAPSACK-PRO-CLIENT-VERSION'
+      ];
+
+      expect(actual).toEqual(clientVersion);
+    });
+
+    it('on GitHub Actions it includes KNAPSACK-PRO-CI-PROVIDER', () => {
+      process.env = { ...process.env, GITHUB_ACTIONS: 'true' };
+
+      const actual = getHeaders({ clientName: '', clientVersion: '' });
+
+      expect(actual['KNAPSACK-PRO-CI-PROVIDER']).toEqual('GitHub Actions');
+    });
+
+    it('with undetected CI it does not include KNAPSACK-PRO-CI-PROVIDER', () => {
+      const actual = getHeaders({ clientName: '', clientVersion: '' });
+
+      expect(actual).not.toHaveProperty('KNAPSACK-PRO-CI-PROVIDER');
+    });
+  });
+});

--- a/packages/core/__tests__/knapsack-pro-env.config.spec.ts
+++ b/packages/core/__tests__/knapsack-pro-env.config.spec.ts
@@ -2,6 +2,7 @@ import {
   KnapsackProEnvConfig,
   buildAuthor,
   commitAuthors,
+  ciProvider,
 } from '../src/config/knapsack-pro-env.config';
 import { KnapsackProLogger } from '../src/knapsack-pro-logger';
 import * as Urls from '../src/urls';
@@ -285,7 +286,7 @@ describe('KnapsackProEnvConfig', () => {
           false,
         ],
         ['Travis CI', { TRAVIS: 'whatever' }, true],
-        ['Unsupported', {}, true],
+        ['Unsupported CI', {}, true],
       ];
       TESTS.forEach(([ci, env, expected]) => {
         it(`on ${ci} it is ${expected} and the default value is logged once`, () => {
@@ -379,6 +380,44 @@ describe('KnapsackProEnvConfig', () => {
         });
 
         expect(actual).toEqual([]);
+      });
+    });
+  });
+
+  describe('ciProvider', () => {
+    const TESTS: [string, object][] = [
+      ['AppVeyor', { APPVEYOR: '123' }],
+      ['Azure Pipelines', { SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: '123' }],
+      ['AWS CodeBuild', { CODEBUILD_BUILD_ARN: '123' }],
+      ['Bamboo', { bamboo_planKey: '123' }],
+      ['Bitbucket Pipelines', { BITBUCKET_COMMIT: '123' }],
+      ['Buddy.works', { BUDDY: 'true' }],
+      ['Buildkite', { BUILDKITE: 'true' }],
+      ['CircleCI', { CIRCLECI: 'true' }],
+      ['Cirrus CI', { CIRRUS_CI: 'true' }],
+      ['Codefresh', { CF_BUILD_ID: '123' }],
+      ['Codeship', { CI_NAME: 'codeship' }],
+      ['Drone.io', { DRONE: 'true' }],
+      ['GitHub Actions', { GITHUB_ACTIONS: 'true' }],
+      ['Gitlab CI', { GITLAB_CI: 'true' }],
+      ['Google Cloud Build', { BUILDER_OUTPUT: '123' }],
+      ['Heroku CI', { HEROKU_TEST_RUN_ID: '123' }],
+      ['Jenkins', { JENKINS_URL: '123' }],
+      ['Semaphore CI 1.0', { SEMAPHORE_BUILD_NUMBER: '123' }],
+      ['Semaphore CI 2.0', { SEMAPHORE: 'true', SEMAPHORE_WORKFLOW_ID: '123' }],
+      ['TeamCity', { TEAMCITY_VERSION: '123' }],
+      ['Travis CI', { TRAVIS: 'true' }],
+      ['Other', { CI: 'true' }],
+      [null, {}],
+    ];
+
+    TESTS.forEach(([ci, env]) => {
+      it(`detects ${ci ?? 'missing CI from env or development'}`, () => {
+        process.env = { ...process.env, ...env };
+
+        const actual = ciProvider();
+
+        expect(actual).toEqual(ci);
       });
     });
   });

--- a/packages/core/src/ci-providers/appveyor.ts
+++ b/packages/core/src/ci-providers/appveyor.ts
@@ -37,4 +37,8 @@ export class AppVeyor extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return false;
   }
+
+  public static get ciProvider(): string {
+    return 'AppVeyor';
+  }
 }

--- a/packages/core/src/ci-providers/buildkite.ts
+++ b/packages/core/src/ci-providers/buildkite.ts
@@ -38,4 +38,8 @@ export class Buildkite extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return true;
   }
+
+  public static get ciProvider(): string {
+    return 'Buildkite';
+  }
 }

--- a/packages/core/src/ci-providers/ci-provider.base.ts
+++ b/packages/core/src/ci-providers/ci-provider.base.ts
@@ -30,4 +30,8 @@ export abstract class CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     throw new Error('fixedQueueSplit getter is not implemented!');
   }
+
+  public static get ciProvider(): string | null {
+    throw new Error('ciProvider getter is not implemented!');
+  }
 }

--- a/packages/core/src/ci-providers/circle-ci.ts
+++ b/packages/core/src/ci-providers/circle-ci.ts
@@ -36,4 +36,8 @@ export class CircleCI extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return false;
   }
+
+  public static get ciProvider(): string {
+    return 'CircleCI';
+  }
 }

--- a/packages/core/src/ci-providers/cirrus-ci.ts
+++ b/packages/core/src/ci-providers/cirrus-ci.ts
@@ -36,4 +36,8 @@ export class CirrusCI extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return false;
   }
+
+  public static get ciProvider(): string {
+    return 'Cirrus CI';
+  }
 }

--- a/packages/core/src/ci-providers/codefresh-ci.ts
+++ b/packages/core/src/ci-providers/codefresh-ci.ts
@@ -37,4 +37,8 @@ export class CodefreshCI extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return false;
   }
+
+  public static get ciProvider(): string {
+    return 'Codefresh';
+  }
 }

--- a/packages/core/src/ci-providers/codeship.ts
+++ b/packages/core/src/ci-providers/codeship.ts
@@ -36,4 +36,8 @@ export class Codeship extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return true;
   }
+
+  public static get ciProvider(): string {
+    return 'Codeship';
+  }
 }

--- a/packages/core/src/ci-providers/github-actions.ts
+++ b/packages/core/src/ci-providers/github-actions.ts
@@ -51,4 +51,8 @@ export class GithubActions extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return true;
   }
+
+  public static get ciProvider(): string {
+    return 'GitHub Actions';
+  }
 }

--- a/packages/core/src/ci-providers/gitlab-ci.ts
+++ b/packages/core/src/ci-providers/gitlab-ci.ts
@@ -48,4 +48,8 @@ export class GitlabCI extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return true;
   }
+
+  public static get ciProvider(): string {
+    return 'Gitlab CI';
+  }
 }

--- a/packages/core/src/ci-providers/heroku-ci.ts
+++ b/packages/core/src/ci-providers/heroku-ci.ts
@@ -36,4 +36,8 @@ export class HerokuCI extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return false;
   }
+
+  public static get ciProvider(): string {
+    return 'Heroku CI';
+  }
 }

--- a/packages/core/src/ci-providers/semaphore-ci-2.ts
+++ b/packages/core/src/ci-providers/semaphore-ci-2.ts
@@ -43,4 +43,8 @@ export class SemaphoreCI2 extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return false;
   }
+
+  public static get ciProvider(): string {
+    return 'Semaphore CI 2.0';
+  }
 }

--- a/packages/core/src/ci-providers/semaphore-ci.ts
+++ b/packages/core/src/ci-providers/semaphore-ci.ts
@@ -43,4 +43,8 @@ export class SemaphoreCI extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return false;
   }
+
+  public static get ciProvider(): string {
+    return 'Semaphore CI 1.0';
+  }
 }

--- a/packages/core/src/ci-providers/travis-ci.ts
+++ b/packages/core/src/ci-providers/travis-ci.ts
@@ -36,4 +36,8 @@ export class TravisCI extends CIProviderBase {
   public static get fixedQueueSplit(): boolean {
     return true;
   }
+
+  public static get ciProvider(): string {
+    return 'Travis CI';
+  }
 }

--- a/packages/core/src/ci-providers/unsupported-ci.ts
+++ b/packages/core/src/ci-providers/unsupported-ci.ts
@@ -1,4 +1,5 @@
 import { CIProviderBase } from '.';
+import { isCI } from '../config';
 
 export class UnsupportedCI extends CIProviderBase {
   public static get ciNodeTotal(): string | undefined {
@@ -31,5 +32,39 @@ export class UnsupportedCI extends CIProviderBase {
 
   public static get fixedQueueSplit(): boolean {
     return true;
+  }
+
+  public static get ciProvider(): string | null {
+    if ('CODEBUILD_BUILD_ARN' in process.env) {
+      return 'AWS CodeBuild';
+    }
+    if ('SYSTEM_TEAMFOUNDATIONCOLLECTIONURI' in process.env) {
+      return 'Azure Pipelines';
+    }
+    if ('bamboo_planKey' in process.env) {
+      return 'Bamboo';
+    }
+    if ('BITBUCKET_COMMIT' in process.env) {
+      return 'Bitbucket Pipelines';
+    }
+    if ('BUDDY' in process.env) {
+      return 'Buddy.works';
+    }
+    if ('DRONE' in process.env) {
+      return 'Drone.io';
+    }
+    if ('BUILDER_OUTPUT' in process.env) {
+      return 'Google Cloud Build';
+    }
+    if ('JENKINS_URL' in process.env) {
+      return 'Jenkins';
+    }
+    if ('TEAMCITY_VERSION' in process.env) {
+      return 'TeamCity';
+    }
+    if (isCI()) {
+      return 'Other';
+    }
+    return null;
   }
 }

--- a/packages/core/src/config/knapsack-pro-env.config.ts
+++ b/packages/core/src/config/knapsack-pro-env.config.ts
@@ -275,7 +275,7 @@ const $commitAuthors = (
 };
 
 const gitCommitAuthors = () => {
-  if (isCI && isShallowRepository()) {
+  if (isCI() && isShallowRepository()) {
     const gitFetchShallowSinceCommand =
       'git fetch --shallow-since "one month ago" --quiet 2>/dev/null';
 

--- a/packages/core/src/config/knapsack-pro-env.config.ts
+++ b/packages/core/src/config/knapsack-pro-env.config.ts
@@ -1,5 +1,5 @@
 import childProcess = require('child_process');
-import { CIEnvConfig, isCI } from '.';
+import { CIEnvConfig, isCI, detectCI } from '.';
 import { KnapsackProLogger } from '../knapsack-pro-logger';
 import * as Urls from '../urls';
 
@@ -298,3 +298,5 @@ const gitCommitAuthors = () => {
 export const commitAuthors = (
   command = gitCommitAuthors,
 ): { commits: number; author: string }[] => $commitAuthors(command);
+
+export const ciProvider = (): string | null => detectCI().ciProvider;

--- a/packages/core/src/knapsack-pro-api.ts
+++ b/packages/core/src/knapsack-pro-api.ts
@@ -1,11 +1,32 @@
 import axios, { AxiosError, AxiosInstance, AxiosPromise } from 'axios';
 
-import { KnapsackProEnvConfig, buildAuthor, commitAuthors } from './config';
+import {
+  KnapsackProEnvConfig,
+  buildAuthor,
+  commitAuthors,
+  ciProvider,
+} from './config';
 import { KnapsackProLogger } from './knapsack-pro-logger';
 import { TestFile } from './models';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const axiosRetry = require('axios-retry');
+
+export const getHeaders = ({
+  clientName,
+  clientVersion,
+}: {
+  clientName: string;
+  clientVersion: string;
+}) => {
+  const ci = ciProvider();
+
+  return {
+    'KNAPSACK-PRO-CLIENT-NAME': clientName,
+    'KNAPSACK-PRO-CLIENT-VERSION': clientVersion,
+    ...(ci !== null ? { 'KNAPSACK-PRO-CI-PROVIDER': ci } : {}),
+  };
+};
 
 export class KnapsackProAPI {
   private readonly api: AxiosInstance;
@@ -87,10 +108,7 @@ export class KnapsackProAPI {
     const apiClient = axios.create({
       baseURL: KnapsackProEnvConfig.endpoint,
       timeout: 15000,
-      headers: {
-        'KNAPSACK-PRO-CLIENT-NAME': clientName,
-        'KNAPSACK-PRO-CLIENT-VERSION': clientVersion,
-      },
+      headers: getHeaders({ clientName, clientVersion }),
     });
 
     axiosRetry(apiClient, {


### PR DESCRIPTION
Goes with: https://github.com/KnapsackPro/knapsack-pro-api/pull/754

Related: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/216

This also fixes a bug in `const gitCommitAuthors`. We should move towards using `strict` in tsconfig to avoid mistakes like this one.