### PR TITLE
Allow importing in TS projects without typescript errors

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Emit declaration files so packages can be imported in TS projects without compiler errors
+
 ## 7.1.0
 
 - Warn when `KNAPSACK_PRO_*` environment variables are set manually if their values could be automatically determined from supported CI environments.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
   ],
   "license": "MIT",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "start": "tsc --watch",
     "build": "rm -rf lib && tsc",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "declaration": true
   },
   "include": ["src/**/*.ts"],
   "extends": "../../tsconfig.base.json"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,6 @@
     "module": "nodenext",
     "noImplicitAny": true,
     "removeComments": true,
-    "target": "es2022",
-    "declaration": true
+    "target": "es2022"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
     "module": "nodenext",
     "noImplicitAny": true,
     "removeComments": true,
-    "target": "es2022"
+    "target": "es2022",
+    "declaration": true
   }
 }


### PR DESCRIPTION
Updates tsconfig.base.json so declaration files are emitted.  Also updates `package.json` for the `core` package with `types` field.  These two changes are needed so consumers working in typescript can import from the core package without compiler errors

- [x] I tagged with the correct `@knapsack-pro/PACKAGE` label
- [x] I added my changes to the *Unreleased* section in the CHANGELOG(s)
