### PR TITLE
fix(playwright): shell- and regex-escape test paths

### DIFF
--- a/packages/playwright/src/knapsack-playwright.ts
+++ b/packages/playwright/src/knapsack-playwright.ts
@@ -45,7 +45,13 @@ async function main() {
 
   const onSuccess: onQueueSuccessType = async (testFiles: TestFile[]) => {
     const paths = testFiles
-      .map((testFile) => `'${testFile.path.replaceAll("'", "'\\''")}'`)
+      .map((testFile) => {
+        const regexEscaped = testFile.path.replace(
+          /[.*+?^${}()|[\]\\]/g,
+          '\\$&',
+        );
+        return `'${regexEscaped.replaceAll("'", "'\\''")}'`;
+      })
       .join(' ');
     const command = `PWTEST_BLOB_DO_NOT_REMOVE=1 npx playwright test ${cliArguments} ${paths}`;
     knapsackProLogger.debug(`Executing: ${command}`);

--- a/packages/playwright/src/knapsack-playwright.ts
+++ b/packages/playwright/src/knapsack-playwright.ts
@@ -44,7 +44,9 @@ async function main() {
   );
 
   const onSuccess: onQueueSuccessType = async (testFiles: TestFile[]) => {
-    const paths = testFiles.map((testFile) => testFile.path).join(' ');
+    const paths = testFiles
+      .map((testFile) => `'${testFile.path.replaceAll("'", "'\\''")}'`)
+      .join(' ');
     const command = `PWTEST_BLOB_DO_NOT_REMOVE=1 npx playwright test ${cliArguments} ${paths}`;
     knapsackProLogger.debug(`Executing: ${command}`);
     spawnSync(command, { shell: true, stdio: 'inherit' });


### PR DESCRIPTION
## Problem

`packages/playwright`'s `onSuccess` joins test file paths with spaces and passes them to `npx playwright test` via `shell: true`. Two related bugs make this break on real-world repos:

### 1. Shell metacharacters break `/bin/sh` parsing

Paths are not shell-escaped, so any shell metacharacter in a path breaks the parser before Playwright ever runs. The batch never produces `.knapsack-pro/batch.json`, and the next `readFileSync('.knapsack-pro/batch.json')` throws ENOENT, failing the whole CI job.

We hit this at Gusto. Our Playwright tests live under route-group folders like `apps/gusto/libs/app-*/src/pages/(layout)/`. The `(` breaks `/bin/sh` parsing on the Knapsack-spawned command:

```
/bin/sh: 1: Syntax error: "(" unexpected
Error: ENOENT: no such file or directory, open '.knapsack-pro/batch.json'
```

### 2. Playwright treats positional args as regex filters

Even with shell-escaping, Playwright's CLI interprets each positional argument as a **regex** matched against test file paths, not a literal path. Paths containing regex metacharacters (`.`, `(`, `)`, `[`, `]`, `*`, `+`, `?`, `^`, `$`, `{`, `}`, `|`, `\`) fail to match the intended file, and Playwright errors with:

```
Error: No tests found
```

I confirmed this layer was necessary by running CI with only the shell-escape fix: batches whose paths had no regex metacharacters ran cleanly, but every batch that included a `(...)`-named folder hit "No tests found".

## Fix

Two-layer escape on each path before joining:

1. **Regex-escape** so Playwright's positional-arg regex matches the literal path.
2. **Single-quote** (with the standard `'\''` inner-quote escape) so the shell passes the regex-escaped string through unchanged.

Organized as two commits:

- `fix(playwright): shell-escape test paths in onSuccess`
- `fix(playwright): regex-escape test paths for Playwright CLI`

## Compatibility

No public API change. Paths with no shell or regex metacharacters behave identically.