### PR TITLE
fix(vitest): return early when queue batch is empty

### DIFF
--- a/packages/vitest/src/knapsack-vitest.ts
+++ b/packages/vitest/src/knapsack-vitest.ts
@@ -48,6 +48,9 @@ async function main() {
   );
 
   const onSuccess: onQueueSuccessType = async (testFiles: TestFile[]) => {
+    if (testFiles.length === 0) {
+      return { recordedTestFiles: [], isTestSuiteGreen: true };
+    }
     const filters = testFiles.map((testFile) => testFile.path);
     const cliOptions = {
       ...cliArguments.options,


### PR DESCRIPTION
## Problem

In queue mode, Knapsack Pro signals agents that the queue is exhausted by returning an empty array from the API. `knapsack-pro-vitest` was passing that empty array directly to `startVitest('test', [], ...)`.

Vitest interprets an empty filter list as "no test files to run" and exits with code 1 (`"No test files found, exiting with code 1"`). The package's `getTestResults` function then reads `process.exitCode !== 1` to determine `isTestSuiteGreen`, so every agent that receives one or more empty batches marks the entire suite as failed — even when all actual tests passed.

## Fix

Return early from `onSuccess` with a green result when `testFiles` is empty. This matches the expected queue-exhausted behaviour: no files assigned to this agent = no failures.

```ts
const onSuccess: onQueueSuccessType = async (testFiles: TestFile[]) => {
+  if (testFiles.length === 0) {
+    return { recordedTestFiles: [], isTestSuiteGreen: true };
+  }
  const filters = testFiles.map((testFile) => testFile.path);
  ...
```

## Reproduction

Observed when using `KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE` with a vitest workspace that uses `projects: [...]` config. On a multi-agent run, agents that receive the queue-exhausted signal log `"No test files found, exiting with code 1"` and the overall suite is reported as failed despite all tests passing.

Workaround currently in use: `--passWithNoTests` CLI flag (which makes vitest exit 0 for empty filter lists). That flag can be dropped once this fix is released.